### PR TITLE
changes for the file to work with gulp 4

### DIFF
--- a/05 scorekeeper-starter/gulpfile.js
+++ b/05 scorekeeper-starter/gulpfile.js
@@ -10,10 +10,9 @@ var gulp = require('gulp'),
 
 var cmd = 'elm make ./Main.elm --output ./bundle.js';
 clear();
-gulp.task('default', ['server', 'watch', 'elm']);
 
 gulp.task('watch', function(cb) {
-  gulp.watch('**/*.elm', ['elm']);
+  gulp.watch('**/*.elm', gulp.series('elm'));
 });
 
 gulp.task('server', function(done) {
@@ -41,3 +40,5 @@ gulp.task('elm', function(cb) {
   });
   counter++;
 });
+
+gulp.task('default', gulp.series('server', 'watch', 'elm'));


### PR DESCRIPTION
There is a problem when we try to run gulp 3 with node 12. So to fix this I had to change my vertions. I've got gulp 4 and node 13 wich work fine. The changes here are to adapt the gulp file to gulp 4 wich has some differences in writing [ https://stackoverflow.com/a/54939126/9208292 ].